### PR TITLE
Add gradle example

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,19 @@
       &lt;version&gt;2.2.1&lt;/version&gt;
   &lt;/dependency&gt;   </code></pre>
 
+      <p>And for Gradle:</p>
+
+      <pre class="prettyprint highlight"><code class="language-groovy" data-lang="groovy">
+  project(':quartz-project') {
+    repositories { 
+      mavenCentral()
+    } 
+    dependencies {
+      compile group: 'org.quartz-scheduler', name: 'quartz', version: '2.3.0'
+    }
+  }
+      </code></pre>
+
       <h2>Using Quartz</h2>
 
       <h3>Instantiate and Start a Scheduler</h3>

--- a/index.html
+++ b/index.html
@@ -200,7 +200,8 @@
       mavenCentral()
     } 
     dependencies {
-      compile group: 'org.quartz-scheduler', name: 'quartz', version: '2.3.0'
+      compile group: 'org.quartz-scheduler', name: 'quartz', version: '2.2.1'
+      compile group: 'org.quartz-scheduler', name: 'quartz-jobs', version: '2.2.1'
     }
   }
       </code></pre>


### PR DESCRIPTION
Adds a snip of an example Gradle project declaring quarts 2.2.1 dependency to go along with Maven since most projects are now using one of the two as a standard

<img width="1187" alt="screen shot 2018-05-15 at 9 28 47 pm" src="https://user-images.githubusercontent.com/24814025/40091687-1aeb9af4-5887-11e8-8925-4a4d99ad3dc4.png">

